### PR TITLE
Package the repo as a plugin, with a license and Codex metadata

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "name": "johnnydecimal",
+  "owner": {
+    "name": "Johnny Noble",
+    "url": "https://johnnydecimal.com"
+  },
+  "description": "Johnny.Decimal agent skills, as an installable Claude Code plugin.",
+  "plugins": [
+    {
+      "name": "johnnydecimal-skills",
+      "source": "./",
+      "description": "Agent skills for working with your Johnny.Decimal system: read and write your JDex, find your files, and keep your notes up to date.",
+      "category": "productivity",
+      "keywords": [
+        "johnny-decimal",
+        "jdex",
+        "notes",
+        "obsidian"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "johnnydecimal-skills",
+  "version": "1.0.0",
+  "description": "Agent skills for working with your Johnny.Decimal system. Read and write your JDex, find your files, and keep your notes up to date.",
+  "author": {
+    "name": "Johnny Noble",
+    "url": "https://johnnydecimal.com"
+  },
+  "homepage": "https://johnnydecimal.com/jdhq/agent-skills",
+  "repository": "https://github.com/johnnydecimal/skills",
+  "license": "MIT",
+  "keywords": [
+    "johnny-decimal",
+    "johnnydecimal",
+    "jdex",
+    "organisation",
+    "notes",
+    "obsidian"
+  ],
+  "skills": [
+    "./skills/jdex",
+    "./skills/johnnydecimal"
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+The version number lives in `.claude-plugin/plugin.json`. Claude Code uses it to decide when installed users get an update, so bump it with every change that reaches a skill.
+
+## 1.0.0
+
+- First versioned release.
+- Add `LICENSE`. The skills are MIT.
+- Add the Claude Code plugin manifest, so `claude plugins install` works as well as `npx skills add`.
+- Add `agents/openai.yaml` to each skill, so Codex shows a display name and a short description.
+- Add `license` and `compatibility` to the skill frontmatter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+> Written by Claude.
+
 The version number lives in `.claude-plugin/plugin.json`. Claude Code uses it to decide when installed users get an update, so bump it with every change that reaches a skill.
 
 ## 1.0.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Johnny Noble
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@ Skills that let an AI agent work with your [Johnny.Decimal](https://johnnydecima
 
 ## Install
 
+There are two routes. Pick one. Both together gives you every skill twice.
+
+### As a Claude Code plugin
+
+A read-only bundle that Claude Code updates for you.
+
+```
+claude plugin marketplace add johnnydecimal/skills
+claude plugin install johnnydecimal-skills@johnnydecimal
+```
+
+Or, from inside a session, `/plugin marketplace add johnnydecimal/skills` and then `/plugin install johnnydecimal-skills@johnnydecimal`.
+
+### As files you own
+
+For Codex, Cursor, and every other agent, and for Claude Code if you want to edit the skills.
+
 ```
 npx skills add johnnydecimal/skills
 ```
@@ -108,6 +125,19 @@ They answer different questions. Tell them apart by their keys.
 
 Neither overrides the other.
 
-## Licence
+## Contributing
 
-Use these however you like.
+Each skill is a folder under `skills/` with a `SKILL.md`. Beside it, `agents/openai.yaml` gives Codex a display name and a short description. Add both to a new skill, and add the folder to the `skills` list in `.claude-plugin/plugin.json`.
+
+The version number is in `.claude-plugin/plugin.json`. Bump it, and add a line to `CHANGELOG.md`, with every change that reaches a skill. Claude Code uses the version to decide when installed users get the update.
+
+Check your work with:
+
+```
+claude plugin validate . --strict
+claude plugin validate skills --strict
+```
+
+## License
+
+MIT. See `LICENSE`.

--- a/skills.code-workspace
+++ b/skills.code-workspace
@@ -1,0 +1,23 @@
+{
+  "folders": [
+    {
+      "path": ".",
+    },
+  ],
+  "settings": {
+    // Palette: one OKLCH hue, 350. Lightness and chroma stay fixed.
+    // VS Code reads hex only, so the hex below is generated from the
+    // oklch() value in each comment. To change the theme, pick a new
+    // hue and convert all six.
+    "workbench.colorCustomizations": {
+      "titleBar.activeBackground": "#e881b4", // oklch(73% 0.140 350)
+      "titleBar.activeForeground": "#fff",
+      "titleBar.inactiveBackground": "#facbe0", // oklch(89% 0.059 350)
+      "window.activeBorder": "#e881b4", // oklch(73% 0.140 350)
+      "sideBar.background": "#fef1f6", // oklch(97% 0.015 350)
+      "commandCenter.background": "#f8bed8", // oklch(86% 0.074 350)
+      "commandCenter.foreground": "#2f1a24", // oklch(25% 0.038 350)
+      "commandCenter.debuggingBackground": "#fce3ee60", // oklch(94% 0.030 350) + 60
+    },
+  },
+}

--- a/skills/jdex/SKILL.md
+++ b/skills/jdex/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: jdex
 description: Read and write to the user's JDex — their Johnny.Decimal index. Use this skill whenever the user mentions their JDex, asks to check, fetch, or update their own documentation, references a Johnny.Decimal ID (e.g. 12.34, W0189), invokes you from a folder with an ID in its name, asks to find a file or document, asks where a document belongs in their JD system, or asks a factual question about their own life or business (e.g. "where does X money go?", "what's the process for Y?", "trace where Z ended up"). The JDex is their knowledge base — treat any investigative or research question about their own information as a JDex lookup first.
+license: MIT
+compatibility: Needs the jd MCP server at https://johnnydecimal.com/mcp, a ~/.jd/config.json, and a shell. Making new IDs needs the JD CLI. Content search needs the obsidian CLI.
 ---
 
 # Prerequisites

--- a/skills/jdex/agents/openai.yaml
+++ b/skills/jdex/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "JDex"
+  short_description: "Read and write your Johnny.Decimal index"

--- a/skills/johnnydecimal/SKILL.md
+++ b/skills/johnnydecimal/SKILL.md
@@ -2,6 +2,7 @@
 name: johnnydecimal
 description: Reference material describing the Johnny.Decimal system — its structure, notation, and conventions. Use this to understand JD concepts when working with JD-related skills.
 user-invocable: false
+license: MIT
 ---
 
 # Where the knowledge lives

--- a/skills/johnnydecimal/agents/openai.yaml
+++ b/skills/johnnydecimal/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Johnny.Decimal reference"
+  short_description: "Reference material on the Johnny.Decimal system, used by the jdex skill"


### PR DESCRIPTION
_Claude wrote this._

Closes #7.

## What

- `LICENSE`, MIT. Also `license: MIT` in each skill's frontmatter.
- `.claude-plugin/plugin.json` and `marketplace.json`. The skills now install as a Claude Code plugin. `npx skills add` still works and is the route for every other agent.
- `agents/openai.yaml` beside each `SKILL.md`, so Codex shows a display name and a short description.
- `compatibility` in the `jdex` frontmatter. It names the MCP server, the config file, the JD CLI, and the Obsidian CLI.
- `CHANGELOG.md` and a version, `1.0.0`, in `plugin.json`.
- README: the two install routes, a contributing note, and the license.

## Checks

```
claude plugin validate . --strict                       # marketplace manifest
claude plugin validate .claude-plugin/plugin.json --strict
claude plugin validate skills --strict
```

All three pass. I did not run `claude plugin marketplace add` against a checkout, because that writes to the user-level Claude config on the machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019nbRkEQ23syc2pf2ggsJqF
