### PR TITLE
jdex: add a Moving in section, release 1.1.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "johnnydecimal-skills",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Agent skills for working with your Johnny.Decimal system. Read and write your JDex, find your files, and keep your notes up to date.",
   "author": {
     "name": "Johnny Noble",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 The version number lives in `.claude-plugin/plugin.json`. Claude Code uses it to decide when installed users get an update, so bump it with every change that reaches a skill.
 
+## 1.1.0
+
+- `jdex`: add a Moving in section. The server's `move_in` tool holds the process. The skill says that `jd move` moves the files, and that the run's state lives in the `00.05` note.
+
 ## 1.0.0
 
 - First versioned release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,30 @@
 
 > Written by Claude.
 
-The version number lives in `.claude-plugin/plugin.json`. Claude Code uses it to decide when installed users get an update, so bump it with every change that reaches a skill.
+The version number lives in `.claude-plugin/plugin.json`. Claude Code uses it to decide when installed users get an update, so bump it with every change that reaches a skill: 1.1.0, 1.2.0, and so on. Each release has a git tag, for example `v1.1.0`, and a GitHub release with the same body as its entry here.
 
-## 1.1.0
+## 1.1.0 – 2026-09-13
 
-- `jdex`: add a Moving in section. The server's `move_in` tool holds the process. The skill says that `jd move` moves the files, and that the run's state lives in the `00.05` note.
+> AI generated. Reviewed by Johnny.
 
-## 1.0.0
+This release adds a Moving in section to the `jdex` skill. Moving in puts
+your existing files into the system you have installed.
+
+### Features
+
+- `jdex` has a Moving in section. The server's `move_in` tool holds the
+  process. The skill holds the local half: the JD CLI moves each file
+  with `jd move`, the run's state lives in the `00.05` note, and the
+  answer to the contents question is recorded once.
+- The prerequisites line now says the skill moves no files itself, and
+  points to Moving in for the CLI.
+
+### Changes
+
+- The README says what Moving in does, and that the JD CLI is also
+  needed to move files.
+
+## 1.0.0 – 2026-09-12
 
 - First versioned release.
 - Add `LICENSE`. The skills are MIT.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Reads and writes your JDex, your Johnny.Decimal index. Ask it to find a file, lo
 
 To make a new ID or work package, it runs the JD CLI, `jd new`. It never writes a new ID by hand. If the CLI is not installed, it gets the install steps from the MCP server.
 
-To file your existing files into your system, it calls the server's `move_in` tool and follows that process. The JD CLI moves each file, with `jd move`. The skill moves nothing itself, and nothing is deleted.
+To put your existing files into your system, it calls the server's `move_in` tool and follows that process. The JD CLI moves each file, with `jd move`. The skill moves nothing itself. Neither the skill nor the CLI deletes a file.
 
 ### `johnnydecimal`
 
@@ -76,7 +76,7 @@ Sign in when prompted. The documentation tools work with any account. The tools 
 
 ### 3. Install the JD CLI, if you want new IDs made or files moved
 
-`jd new` makes IDs and work packages. `jd move` files your existing files. Ask your agent to install the JD CLI. The MCP server has the steps. Without it, the skill reads and writes notes but does not make new IDs.
+`jd new` makes IDs and work packages. `jd move` puts your existing files into your system. Ask your agent to install the JD CLI. The MCP server has the steps. Without it, the skill reads and writes notes, but it makes no new IDs and moves no files.
 
 ## Which ID am I working on?
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,13 @@ Each skill is a folder under `skills/` with a `SKILL.md`. Beside it, `agents/ope
 
 The version number is in `.claude-plugin/plugin.json`. Bump it, and add a line to `CHANGELOG.md`, with every change that reaches a skill. Claude Code uses the version to decide when installed users get the update.
 
+To release, merge to `main`, then tag the merge commit `vX.Y.Z` and make a GitHub release with the changelog entry as its body:
+
+```
+git tag -a v1.1.0 -m "1.1.0" && git push origin v1.1.0
+gh release create v1.1.0 --title 1.1.0 --notes-file <the entry>
+```
+
 Check your work with:
 
 ```

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Reads and writes your JDex, your Johnny.Decimal index. Ask it to find a file, lo
 
 To make a new ID or work package, it runs the JD CLI, `jd new`. It never writes a new ID by hand. If the CLI is not installed, it gets the install steps from the MCP server.
 
+To file your existing files into your system, it calls the server's `move_in` tool and follows that process. The JD CLI moves each file, with `jd move`. The skill moves nothing itself, and nothing is deleted.
+
 ### `johnnydecimal`
 
 Reference material on how Johnny.Decimal works. You do not invoke this one. The `jdex` skill loads it when it needs it.
@@ -72,9 +74,9 @@ claude mcp add --transport http jd https://johnnydecimal.com/mcp
 
 Sign in when prompted. The documentation tools work with any account. The tools that serve a published system need an account that owns that system.
 
-### 3. Install the JD CLI, if you want new IDs made
+### 3. Install the JD CLI, if you want new IDs made or files moved
 
-`jd new` makes IDs and work packages. Ask your agent to install the JD CLI. The MCP server has the steps. Without it, the skill reads and writes notes but does not make new IDs.
+`jd new` makes IDs and work packages. `jd move` files your existing files. Ask your agent to install the JD CLI. The MCP server has the steps. Without it, the skill reads and writes notes but does not make new IDs.
 
 ## Which ID am I working on?
 

--- a/skills/jdex/SKILL.md
+++ b/skills/jdex/SKILL.md
@@ -2,13 +2,13 @@
 name: jdex
 description: Read and write to the user's JDex — their Johnny.Decimal index. Use this skill whenever the user mentions their JDex, asks to check, fetch, or update their own documentation, references a Johnny.Decimal ID (e.g. 12.34, W0189), invokes you from a folder with an ID in its name, asks to find a file or document, asks where a document belongs in their JD system, or asks a factual question about their own life or business (e.g. "where does X money go?", "what's the process for Y?", "trace where Z ended up"). The JDex is their knowledge base — treat any investigative or research question about their own information as a JDex lookup first.
 license: MIT
-compatibility: Needs the jd MCP server at https://johnnydecimal.com/mcp, a ~/.jd/config.json, and a shell. Making new IDs needs the JD CLI. Content search needs the obsidian CLI.
+compatibility: Needs the jd MCP server at https://johnnydecimal.com/mcp, a ~/.jd/config.json, and a shell. Making new IDs and moving files needs the JD CLI. Content search needs the obsidian CLI.
 ---
 
 # Prerequisites
 
 - This skill requires the `johnnydecimal` skill for JD system context.
-- This skill finds things and writes notes. It does not move files. If the user wants documents filed into their JD filesystem, tell them where each one belongs and let them move it, or ask before you move anything yourself.
+- This skill finds things and writes notes. It moves no files itself. If the user wants their existing files filed into their system, the JD CLI moves them, under Moving in below. Otherwise, tell the user where each file belongs and let them move it.
 
 # The jd MCP server
 
@@ -200,6 +200,14 @@ The ID it made is your active ID from then on. Read its note before you write to
 If the CLI is not installed, call `install_cli` on the server and follow its steps. If the server is not connected either, stop and say so. Do not make the ID by hand.
 
 The one exception is the `AC.05` note, above. It has a fixed number, and its folder is not yours to make, so you write that note yourself.
+
+# Moving in
+
+Moving in files the user's existing files into the system they have installed. The process is the server's, not this skill's. When the user wants their existing files in their system, call `move_in` with the system, `las` or `sbs`, and follow the text it returns. This skill carries the local half only. It repeats no step of the process.
+
+- Files move with the CLI: `~/.jd/cli/bin/jd move <path> <id> --json`. Use that full path. Never run `mv`. Never delete a file or a folder. This is the same rule as new IDs and work packages: the CLI writes to the user's machine, not you. `jd move` is a beta feature, like `jd new`.
+- The run's state lives in the `00.05` note, under one heading, `## yyyy-mm-dd Moving in`. The tool names the sub-headings under it. Read that section first in every session, before anything else. The section is yours: tag it as Writing things says.
+- Reading inside files is the user's choice. The process asks once and records the answer in that note. Keep to the recorded answer. Do not ask again.
 
 # Finding things
 

--- a/skills/jdex/SKILL.md
+++ b/skills/jdex/SKILL.md
@@ -203,11 +203,11 @@ The one exception is the `AC.05` note, above. It has a fixed number, and its fol
 
 # Moving in
 
-Moving in files the user's existing files into the system they have installed. The process is the server's, not this skill's. When the user wants their existing files in their system, call `move_in` with the system, `las` or `sbs`, and follow the text it returns. This skill carries the local half only. It repeats no step of the process.
+Moving in puts the user's existing files into the system they have installed. The server's `move_in` tool holds the process. This skill holds the rules for the CLI and the note, and nothing more. When the user wants their existing files in their system, call `move_in` with the system, `las` or `sbs`. Follow the text it returns.
 
-- Files move with the CLI: `~/.jd/cli/bin/jd move <path> <id> --json`. Use that full path. Never run `mv`. Never delete a file or a folder. This is the same rule as new IDs and work packages: the CLI writes to the user's machine, not you. `jd move` is a beta feature, like `jd new`.
-- The run's state lives in the `00.05` note, under one heading, `## yyyy-mm-dd Moving in`. The tool names the sub-headings under it. Read that section first in every session, before anything else. The section is yours: tag it as Writing things says.
-- Reading inside files is the user's choice. The process asks once and records the answer in that note. Keep to the recorded answer. Do not ask again.
+- Files move with `~/.jd/cli/bin/jd move`. Use that full path. Never run `mv`. Never delete a file or a folder. The CLI moves files, not you. The same rule holds for new IDs, under Creating things above.
+- The run's state lives in the `00.05` note, under one heading, `## yyyy-mm-dd Moving in`. `move_in` names the sub-headings under it. Read that section first in every session. The section is yours. Mark it the way Writing things, above, says.
+- Reading inside files is the user's choice. `move_in` asks once and records the answer in that note. Keep to the recorded answer. Do not ask again.
 
 # Finding things
 


### PR DESCRIPTION
Closes #6.

The `jdex` skill gets a Moving in section. The server's `move_in` tool holds the process. The skill holds the local half: the JD CLI moves each file with `jd move`, the run's state lives in the `00.05` note, and the answer to the contents question is recorded once. The prerequisites line still says the skill moves no files itself.

The version is 1.1.0. The changelog entry has the CLI's shape, and the README says how to tag and release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKMzcrw6AZvz7RYR9bAFYo
